### PR TITLE
TypeScript migration (rebased) + Dockerfile fix, command test suite, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies required by node-canvas
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3 \
+            build-essential \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libjpeg-dev \
+            libgif-dev \
+            librsvg2-dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting (prettier)
+        run: npm run format:check
+
+      - name: Run tests
+        run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && apt-get install -y \
 COPY package*.json ./
 RUN npm ci --omit=dev
 
-# Stage 2: dev dependencies (adds devDependencies like nodemon on top of deps)
+# Stage 2: dev dependencies (adds devDependencies like typescript on top of deps)
 FROM deps AS dev-deps
 RUN npm ci
 
 # Stage 3: development image, used by docker-compose.dev.yml (target: dev).
 # Keeps the build toolchain so canvas can rebuild if node_modules ever needs
-# it, and runs via nodemon for auto-reload on file changes.
+# it, and runs via tsx watch mode for auto-reload on file changes.
 FROM node:20-slim AS dev
 WORKDIR /usr/src/app
 
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 COPY --from=dev-deps /usr/src/app/node_modules ./node_modules
 COPY . .
 
-CMD ["npx", "nodemon", "index.js"]
+CMD ["npx", "tsx", "watch", "index.ts"]
 
 # Stage 4: production app image
 FROM node:20-slim AS app
@@ -64,4 +64,4 @@ USER appuser
 ENV NODE_ENV=production
 
 EXPOSE 3000
-CMD ["node", "index.js"]
+CMD ["npx", "tsx", "index.ts"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ live code mounting - editing source won't do anything until you rebuild.
 
 For active development, use `docker-compose.dev.yml` instead: it builds the
 `dev` image stage, bind-mounts your working directory into the container, and
-runs the bot via `nodemon`, so code changes are picked up automatically
+runs the bot via `tsx` watch mode, so code changes are picked up automatically
 without a rebuild or manual restart.
 
 - `docker compose -f docker-compose.dev.yml up -d --build` (rebuild only needed when dependencies change, e.g. `package.json`)
@@ -31,7 +31,7 @@ Alternatively, open the repo in VS Code with the
 extension installed and run **Dev Containers: Reopen in Container** — this
 uses the same `docker-compose.dev.yml` setup under `.devcontainer/`, giving
 you an integrated terminal/debugger inside the container with the bot
-already running via nodemon.
+already running via tsx watch mode.
 
 ### Running tests
 

--- a/commands/adversaryRules.js
+++ b/commands/adversaryRules.js
@@ -160,7 +160,9 @@ module.exports = {
     }
 
     if (leadLoss || suppLoss) {
-      lines.push(leadLoss && suppLoss ? "### Loss Conditions" : "### Loss Condition");
+      lines.push(
+        leadLoss && suppLoss ? "### Loss Conditions" : "### Loss Condition",
+      );
       if (leadLoss) lines.push(`- **${leadLoss.name}** — ${leadLoss.effect}`);
       if (suppLoss) lines.push(`- **${suppLoss.name}** — ${suppLoss.effect}`);
     }

--- a/commands/healing.js
+++ b/commands/healing.js
@@ -25,10 +25,15 @@ module.exports = {
 
     if (args.length > 0) {
       // if there's no side provided, assume they want the useful side
-      const side = (args.length > 1 ? (
-        getSide(args[0], () => { return args.shift() }) ||
-        getSide(args[args.length - 1], () => { return args.pop() })
-      ) : undefined) || "front";
+      const side =
+        (args.length > 1
+          ? getSide(args[0], () => {
+              return args.shift();
+            }) ||
+            getSide(args[args.length - 1], () => {
+              return args.pop();
+            })
+          : undefined) || "front";
       var healingNames = [];
       const searchString = args.join(" ").toLowerCase();
       for (const hc of heal.healing) {

--- a/commands/scenarioNames.js
+++ b/commands/scenarioNames.js
@@ -1,12 +1,11 @@
 var blitz = {
-    name: "Blitz",
-    front: "front",
-    back: "back",
-    difficulty: "0",
-    link: "https://i.imgur.com/l9LsFb7.png" ,
-    linkBack: "https://i.imgur.com/rbm2vox" 
-
-}
+  name: "Blitz",
+  front: "front",
+  back: "back",
+  difficulty: "0",
+  link: "https://i.imgur.com/l9LsFb7.png",
+  linkBack: "https://i.imgur.com/rbm2vox",
+};
 
 var GtIH = {
   name: "Guard the Isle's Heart",

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ app.listen(HEALTH_PORT, () => {
 });
 // --- end health server ---
 
-bot.commands = new Collection();
+commands = new Collection();
 
 const commandFiles = fs
   .readdirSync("./commands/")
@@ -55,7 +55,7 @@ const commandFiles = fs
 
 for (const file of commandFiles) {
   const command = require(`./commands/${file}`);
-  bot.commands.set(command.name, command);
+  commands.set(command.name, command);
 }
 
 bot.once("ready", async () => {
@@ -68,7 +68,7 @@ bot.once("ready", async () => {
     status: "online",
   });
 
-  console.log(bot.commands.get("spirit").name);
+  console.log(commands.get("spirit").name);
 });
 
 bot.on("messageCreate", async (msg) => {
@@ -77,10 +77,10 @@ bot.on("messageCreate", async (msg) => {
   let command = args.shift().toLowerCase();
   console.log(command);
 
-  if (!bot.commands.has(command)) return console.log("command not in list");
+  if (!commands.has(command)) return console.log("command not in list");
 
   try {
-    await bot.commands.get(command).execute(msg, args, Discord);
+    await commands.get(command).execute(msg, args, Discord);
   } catch (error) {
     console.error(error);
   }

--- a/index.ts
+++ b/index.ts
@@ -1,18 +1,24 @@
 /* Loads all associated commands and exposes health endpoint
  */
 
-require("dotenv").config();
-const fs = require("fs");
-const Discord = require("discord.js");
-const express = require("express");
-
-const {
+import dotenv from "dotenv";
+import { readdirSync } from "fs";
+import { createRequire } from "module";
+import {
   Client,
   Collection,
   GatewayIntentBits,
   Partials,
   ActivityType,
-} = require("discord.js");
+} from "discord.js";
+import * as Discord from "discord.js";
+import express from "express";
+
+dotenv.config();
+
+// TODO-ts-migration remove this once everything uses `import`
+const require = createRequire(import.meta.url);
+
 const bot = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -31,12 +37,12 @@ let ready = false; // readiness flag
 const app = express();
 const HEALTH_PORT = parseInt(process.env.HEALTH_PORT || "3000", 10);
 
-app.get("/healthz", (req, res) => {
+app.get("/healthz", (_req: any, res: any) => {
   // basic liveness: process up
   res.status(200).send("ok");
 });
 
-app.get("/ready", (req, res) => {
+app.get("/ready", (_req: any, res: any) => {
   // readiness: bot connected and ready to serve
   if (ready) return res.status(200).send("ready");
   return res.status(503).send("not ready");
@@ -47,14 +53,22 @@ app.listen(HEALTH_PORT, () => {
 });
 // --- end health server ---
 
-commands = new Collection();
+type CommandModule = {
+  name: string;
+  // TODO-ts-migration modules shouldn't need discord, they can just import it..
+  execute: (msg: Discord.Message, args: string[], discord: typeof Discord) => any;
+};
 
-const commandFiles = fs
-  .readdirSync("./commands/")
-  .filter((file) => file.endsWith(".js"));
+const commands: Collection<string, CommandModule> = new Collection();
+
+const commandFiles = readdirSync("./commands/").filter((file) => file.endsWith(".js") || file.endsWith(".ts"));
 
 for (const file of commandFiles) {
-  const command = require(`./commands/${file}`);
+  const command = require(`./commands/${file}`) as CommandModule;
+  if (!command?.name || typeof command.execute !== "function") {
+    continue;
+  }
+
   commands.set(command.name, command);
 }
 
@@ -63,24 +77,26 @@ bot.once("ready", async () => {
   ready = true;
 
   // Set bot's presence
-  bot.user.setPresence({
+  bot.user?.setPresence({
     activities: [{ name: `for -help`, type: ActivityType.Watching }],
     status: "online",
   });
 
-  console.log(commands.get("spirit").name);
+  console.log(commands.get("spirit")?.name);
 });
 
 bot.on("messageCreate", async (msg) => {
   if (!msg.content.startsWith(PREFIX)) return;
   let args = msg.content.slice(PREFIX.length).trim().split(" ");
-  let command = args.shift().toLowerCase();
+  let command = args.shift()?.toLowerCase();
   console.log(command);
+
+  if (!command) return;
 
   if (!commands.has(command)) return console.log("command not in list");
 
   try {
-    await commands.get(command).execute(msg, args, Discord);
+    await commands.get(command)?.execute(msg, args, Discord);
   } catch (error) {
     console.error(error);
   }
@@ -91,7 +107,7 @@ if (!process.env.DISCORD_TOKEN) {
   console.error("Missing DISCORD_TOKEN in environment");
   process.exit(1);
 }
-bot.login(process.env.DISCORD_TOKEN).catch((err) => {
+await bot.login(process.env.DISCORD_TOKEN).catch((err) => {
   console.error("Failed to login:", err);
   process.exit(1);
 });

--- a/index.ts
+++ b/index.ts
@@ -56,12 +56,18 @@ app.listen(HEALTH_PORT, () => {
 type CommandModule = {
   name: string;
   // TODO-ts-migration modules shouldn't need discord, they can just import it..
-  execute: (msg: Discord.Message, args: string[], discord: typeof Discord) => any;
+  execute: (
+    msg: Discord.Message,
+    args: string[],
+    discord: typeof Discord,
+  ) => any;
 };
 
 const commands: Collection<string, CommandModule> = new Collection();
 
-const commandFiles = readdirSync("./commands/").filter((file) => file.endsWith(".js") || file.endsWith(".ts"));
+const commandFiles = readdirSync("./commands/").filter(
+  (file) => file.endsWith(".js") || file.endsWith(".ts"),
+);
 
 for (const file of commandFiles) {
   const command = require(`./commands/${file}`) as CommandModule;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,22 +15,25 @@
         "await-to-js": "^2.1.1",
         "canvas": "^3.2.3",
         "discord.js": "^14.26.4",
-        "dotenv": "^8.2.0",
+        "dotenv": "^16.4.5",
         "express": "^5.2.1",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^3.2.6",
         "request": "^2.88.2",
+        "tsx": "^4.21.0",
         "twemoji-parser": "^14.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
+        "@types/express": "^4.17.18",
+        "@types/node": "^20.17.0",
         "eslint": "^9.34.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "globals": "^16.3.0",
         "jest": "^29.7.0",
-        "nodemon": "^3.1.14",
-        "prettier": "3.6.2"
+        "prettier": "3.6.2",
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": "20.x",
@@ -685,6 +688,422 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1465,12 +1884,59 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -1481,6 +1947,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1516,13 +1989,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1911,19 +2438,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2196,44 +2710,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/chownr": {
@@ -2605,12 +3081,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -2726,6 +3205,47 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -3409,7 +3929,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3746,13 +4265,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3849,19 +4361,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -5136,110 +5635,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nodemon": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
-      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^10.2.1",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5664,13 +6059,6 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -5783,19 +6171,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/request": {
@@ -6169,32 +6544,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6485,16 +6834,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -6519,6 +6858,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -6619,12 +6976,19 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
-      "license": "MIT"
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "test": "jest",
     "start": "tsx index.ts",
-    "dev": "tsx watch index.ts"
+    "dev": "tsx watch index.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "engines": {
     "npm": "10.x",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "si_bot",
   "version": "2.8.2",
   "description": "Spirit Island Catalog bot",
-  "main": "index.js",
+  "type": "module",
+  "main": "index.ts",
   "scripts": {
     "test": "jest",
-    "start": "node index.js",
-    "dev": "nodemon index.js"
+    "start": "tsx index.ts",
+    "dev": "tsx watch index.ts"
   },
   "engines": {
     "npm": "10.x",
@@ -21,11 +22,12 @@
     "await-to-js": "^2.1.1",
     "canvas": "^3.2.3",
     "discord.js": "^14.26.4",
-    "dotenv": "^8.2.0",
+    "dotenv": "^16.4.5",
     "express": "^5.2.1",
     "js-levenshtein": "^1.1.6",
     "node-fetch": "^3.2.6",
     "request": "^2.88.2",
+    "tsx": "^4.21.0",
     "twemoji-parser": "^14.0.0"
   },
   "repository": {
@@ -39,12 +41,14 @@
   "homepage": "https://github.com/thirdratecyberpunk/SI_Card_Bot#readme",
   "devDependencies": {
     "@eslint/js": "^9.34.0",
+    "@types/express": "^4.17.18",
+    "@types/node": "^20.17.0",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "globals": "^16.3.0",
     "jest": "^29.7.0",
-    "nodemon": "^3.1.14",
-    "prettier": "3.6.2"
+    "prettier": "3.6.2",
+    "typescript": "^6.0.2"
   }
 }

--- a/renderers/adversaryCardRenderer.js
+++ b/renderers/adversaryCardRenderer.js
@@ -240,7 +240,15 @@ function drawRichLine(ctx, text, x, y, startInParen) {
 
 // Draws one line of a "{Name}: effect" / "{Name} — effect" group, bolding the
 // name prefix on the first line only. Returns the paren state for the next line.
-function drawNamedEffectLine(ctx, line, x, y, boldPrefixLength, isFirstLine, parenState) {
+function drawNamedEffectLine(
+  ctx,
+  line,
+  x,
+  y,
+  boldPrefixLength,
+  isFirstLine,
+  parenState,
+) {
   if (isFirstLine && boldPrefixLength > 0) {
     const boldLen = Math.min(boldPrefixLength, line.length);
     const namePart = line.slice(0, boldLen);
@@ -268,7 +276,13 @@ function drawEscalationNameEffect(ctx, text, x, y, escName) {
     fillBoldText(ctx, namePart, cursorX, y);
     cursorX += ctx.measureText(namePart).width;
 
-    return drawRichLine(ctx, text.slice(combinedPrefix.length), cursorX, y, false);
+    return drawRichLine(
+      ctx,
+      text.slice(combinedPrefix.length),
+      cursorX,
+      y,
+      false,
+    );
   }
   return drawRichLine(ctx, text, x, y, false);
 }
@@ -303,7 +317,9 @@ async function renderAdversaryCard(data) {
   // An adversary that individually lacks one is simply left out, not shown as "None".
   const hasLossConditions = Boolean(leadLoss) || Boolean(suppLoss);
   const lossConditionsLabel =
-    Boolean(leadLoss) && Boolean(suppLoss) ? "Loss Conditions" : "Loss Condition";
+    Boolean(leadLoss) && Boolean(suppLoss)
+      ? "Loss Conditions"
+      : "Loss Condition";
 
   // --- NULL‑SAFE NORMALIZATION ---
   const safeLeadEsc = leadEsc ?? {
@@ -517,7 +533,9 @@ async function renderAdversaryCard(data) {
   await preloadIcons([...neededIconFiles]);
 
   // --- STACKING ORDER ---
-  const lossEscHeight = hasLossConditions ? Math.max(lossHeight, escHeight) : escHeight;
+  const lossEscHeight = hasLossConditions
+    ? Math.max(lossHeight, escHeight)
+    : escHeight;
   const summaryHeight = 40;
 
   const totalHeight =
@@ -598,9 +616,14 @@ async function renderAdversaryCard(data) {
 
   ctx.font = summaryFont;
   const difficultyValueText = `${combinedDifficulty}`;
-  ctx.fillText(difficultyValueText, padding + difficultyLabelWidth + 10, summaryY);
+  ctx.fillText(
+    difficultyValueText,
+    padding + difficultyLabelWidth + 10,
+    summaryY,
+  );
   const difficultyValueWidth = ctx.measureText(difficultyValueText).width;
-  const difficultyGroupEndX = padding + difficultyLabelWidth + 10 + difficultyValueWidth;
+  const difficultyGroupEndX =
+    padding + difficultyLabelWidth + 10 + difficultyValueWidth;
 
   // Invader Deck — rightmost
   ctx.font = `28px ${BODY_FONT_FAMILY}`;
@@ -728,7 +751,13 @@ async function renderAdversaryCard(data) {
           ? iconH * (escalationIcon.width / escalationIcon.height)
           : iconH;
         cursorX += ICON_GAP;
-        ctx.drawImage(escalationIcon, cursorX, lineY - ICON_SIZE * 0.78, iconW, iconH);
+        ctx.drawImage(
+          escalationIcon,
+          cursorX,
+          lineY - ICON_SIZE * 0.78,
+          iconW,
+          iconH,
+        );
         cursorX += iconW + ICON_GAP;
       }
 

--- a/tests/commandLoader.test.js
+++ b/tests/commandLoader.test.js
@@ -1,0 +1,120 @@
+const fs = require("fs");
+const path = require("path");
+
+const COMMANDS_DIR = path.join(__dirname, "..", "commands");
+
+/**
+ * Mirrors index.ts's dynamic command-loading loop exactly: read every file
+ * in commands/ ending in .js or .ts, require it, and register it if it
+ * exposes a `name` string and a callable `execute`. This is the loader the
+ * TypeScript migration changed (index.js -> index.ts, require() via
+ * createRequire), so it's the most direct regression check for "did the
+ * migration still wire every command up correctly".
+ */
+function loadCommands() {
+  const commandFiles = fs
+    .readdirSync(COMMANDS_DIR)
+    .filter((file) => file.endsWith(".js") || file.endsWith(".ts"));
+
+  const commands = new Map();
+  const namesByFile = new Map();
+  const skippedFiles = [];
+
+  for (const file of commandFiles) {
+    const command = require(path.join(COMMANDS_DIR, file));
+    if (!command?.name || typeof command.execute !== "function") {
+      skippedFiles.push(file);
+      continue;
+    }
+    commands.set(command.name, command);
+    namesByFile.set(file, command.name);
+  }
+
+  return { commandFiles, commands, namesByFile, skippedFiles };
+}
+
+describe("command loader (mirrors index.ts's dynamic require loop)", () => {
+  const { commandFiles, commands, namesByFile, skippedFiles } = loadCommands();
+
+  it("finds command files in commands/", () => {
+    expect(commandFiles.length).toBeGreaterThan(0);
+  });
+
+  it("requires every command file without throwing and registers a name + execute()", () => {
+    // Getting this far already proves every require() succeeded; also assert
+    // the loader actually picked some of them up as real commands.
+    expect(commands.size).toBeGreaterThan(0);
+    for (const [name, command] of commands) {
+      expect(typeof name).toBe("string");
+      expect(name.length).toBeGreaterThan(0);
+      expect(typeof command.execute).toBe("function");
+    }
+  });
+
+  it("registers every command documented in -help", () => {
+    const documented = [
+      "search",
+      "draw",
+      "dtnw",
+      "take",
+      "power",
+      "minor",
+      "major",
+      "unique",
+      "uniques",
+      "blight",
+      "board",
+      "event",
+      "fear",
+      "faq",
+      "adversary",
+      "adversaryrules",
+      "random",
+      "spirit",
+      "aspect",
+      "aspects",
+      "healing",
+      "incarna",
+      "scenario",
+      "invaderdeck",
+      "progression",
+      "feardeck",
+      "help",
+    ];
+    for (const name of documented) {
+      expect(commands.has(name)).toBe(true);
+    }
+  });
+
+  it("gives every command a unique name (no file silently shadows another)", () => {
+    const filesByName = new Map();
+    for (const [file, name] of namesByFile) {
+      if (!filesByName.has(name)) filesByName.set(name, []);
+      filesByName.get(name).push(file);
+    }
+    const collisions = [...filesByName.entries()].filter(
+      ([, files]) => files.length > 1,
+    );
+    expect(collisions).toEqual([]);
+  });
+
+  it("only skips files that are genuinely data/helper modules, not commands", () => {
+    // These files are require()'d by command modules for data or shared
+    // logic; they intentionally have no top-level `name` + `execute` and
+    // are never dispatched to directly by index.ts.
+    const expectedNonCommandFiles = [
+      "AdversaryNames.js",
+      "boardNames.js",
+      "complexities.js",
+      "Deck.js",
+      "ImageNames.js",
+      "InvaderDeckCard.js",
+      "healingNames.js",
+      "incarnaNames.js",
+      "scenarioNames.js",
+      "sendCardLink.js",
+      "spiritNames.js",
+    ];
+    expect(skippedFiles.sort()).toEqual(expectedNonCommandFiles.sort());
+  });
+});

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -1,0 +1,555 @@
+/**
+ * Smoke/regression tests for every commands/*.js module, run the same way
+ * index.ts dispatches them: command.execute(msg, args, Discord). Goal is to
+ * catch anything the TS migration (index.js -> index.ts, createRequire-based
+ * loading) could plausibly break: a command that throws on load, a command
+ * whose output shape changed, or one that stops calling msg.channel.send.
+ *
+ * Expected values below were captured by actually running each command
+ * against the real data files (spiritNames.js, AdversaryNames.js, etc.) as
+ * of this commit — this is the regression baseline, not a spec, so update
+ * the expectations here if a future change intentionally alters output.
+ */
+// commands/ has its own (stray, duplicate) node_modules, so a plain
+// jest.mock("@sapphire/discord.js-utilities", ...) mocks the copy resolved
+// from tests/ while spirit.js/aspects.js resolve the copy nested under
+// commands/node_modules/ — resolve from the same place they do so the mock
+// actually intercepts what they require.
+jest.mock(
+  require.resolve("@sapphire/discord.js-utilities", {
+    paths: [require("path").join(__dirname, "..", "commands")],
+  }),
+  () => require("./helpers/discordMocks").paginatedMessageMock(),
+);
+
+const { createMockMessage } = require("./helpers/discordMocks");
+
+const globals = require("../globals.js");
+
+const adversary = require("../commands/adversary.js");
+const adversaryRules = require("../commands/adversaryRules.js");
+const aspect = require("../commands/aspect.js");
+const aspects = require("../commands/aspects.js");
+const blight = require("../commands/blight.js");
+const board = require("../commands/board.js");
+const card = require("../commands/card.js");
+const choose = require("../commands/choose.js");
+const days = require("../commands/days.js");
+const deckCalc = require("../commands/deckCalc.js");
+const draw = require("../commands/draw.js");
+const event = require("../commands/event.js");
+const faq = require("../commands/faq.js");
+const fear = require("../commands/fear.js");
+const fearDeck = require("../commands/fearDeck.js");
+const healing = require("../commands/healing.js");
+const help = require("../commands/help.js");
+const incarna = require("../commands/incarna.js");
+const major = require("../commands/major.js");
+const minor = require("../commands/minor.js");
+const power = require("../commands/power.js");
+const powerProgression = require("../commands/powerProgression.js");
+const random = require("../commands/random.js");
+const role = require("../commands/role.js");
+const roleAdd = require("../commands/roleAdd.js");
+const scenario = require("../commands/scenario.js");
+const search = require("../commands/search.js");
+const spirit = require("../commands/spirit.js");
+const take = require("../commands/take.js");
+const unique = require("../commands/unique.js");
+const uniques = require("../commands/uniques.js");
+
+// A spirit with both aspects and uniques, but no powerProgression, so it
+// exercises both the "found" and "field absent" branches across commands.
+const TEST_SPIRIT_ARGS = ["A", "Spread", "of", "Rampant", "Green"];
+
+describe("adversary", () => {
+  it("returns the panel for a known adversary", async () => {
+    const msg = createMockMessage();
+    await adversary.execute(msg, ["prussia"]);
+    expect(msg.channel.send).toHaveBeenCalledWith("https://imgur.com/KdyfP3C");
+  });
+
+  it("lists all adversaries when given no args", async () => {
+    const msg = createMockMessage();
+    await adversary.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Choose an adversary:"),
+    );
+  });
+});
+
+describe("adversaryrules", () => {
+  it("renders a PNG card for a single adversary/level", async () => {
+    const msg = createMockMessage();
+    await adversaryRules.execute(msg, ["prussia", "0"]);
+    expect(msg.reply).toHaveBeenCalledTimes(1);
+    const arg = msg.reply.mock.calls[0][0];
+    expect(Array.isArray(arg.files)).toBe(true);
+    expect(Buffer.isBuffer(arg.files[0].attachment)).toBe(true);
+    expect(arg.files[0].attachment.length).toBeGreaterThan(0);
+  });
+
+  it("renders a PNG card for a double adversary setup", async () => {
+    const msg = createMockMessage();
+    await adversaryRules.execute(msg, ["prussia", "0", "england", "0"]);
+    const arg = msg.reply.mock.calls[0][0];
+    expect(Buffer.isBuffer(arg.files[0].attachment)).toBe(true);
+  });
+
+  it("replies with an error for an unknown adversary instead of throwing", async () => {
+    const msg = createMockMessage();
+    await adversaryRules.execute(msg, ["bogus", "0"]);
+    expect(msg.reply).toHaveBeenCalledWith(
+      expect.stringContaining("Leading adversary not found"),
+    );
+  });
+});
+
+describe("aspect", () => {
+  it("returns the panel for an aspect name", async () => {
+    const msg = createMockMessage();
+    await aspect.execute(msg, ["Regrowth"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://i.imgur.com/jQWp7vu.png",
+    );
+  });
+
+  it("shows usage when given no args", async () => {
+    const msg = createMockMessage();
+    await aspect.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Usage: aspect"),
+    );
+  });
+});
+
+describe("aspects", () => {
+  it("lists a spirit's aspects", async () => {
+    const msg = createMockMessage();
+    await aspects.execute(msg, TEST_SPIRIT_ARGS);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("has the following aspects"),
+    );
+  });
+
+  it("sends a paginated list when given no args", async () => {
+    const msg = createMockMessage();
+    await aspects.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringMatching(/^__paginated__ pages=\d+$/),
+    );
+  });
+});
+
+describe("blight", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await blight.execute(msg, ["downward_spiral"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/blights/downward_spiral.webp",
+    );
+  });
+});
+
+describe("board", () => {
+  it("returns the image for a board letter", async () => {
+    const msg = createMockMessage();
+    await board.execute(msg, ["a"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://spiritislandwiki.com/images/e/e2/Piece_core_board_a.png",
+    );
+  });
+
+  it("shows help text when given no args", async () => {
+    const msg = createMockMessage();
+    await board.execute(msg, [""]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Type the board name"),
+    );
+  });
+});
+
+describe("card (delegates to power)", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await card.execute(msg, ["fields_choked_with_growth"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/powers/fields_choked_with_growth.webp",
+    );
+  });
+});
+
+describe("choose", () => {
+  afterEach(() => {
+    globals.choices = [];
+  });
+
+  it("sends the value at the chosen index", async () => {
+    globals.choices = [
+      { label: "opt1", value: "chosen value 1" },
+      { label: "opt2", value: "chosen value 2" },
+    ];
+    const msg = createMockMessage();
+    await choose.execute(msg, ["1"]);
+    expect(msg.channel.send).toHaveBeenCalledWith("chosen value 1");
+  });
+
+  it("rejects an out-of-range index", async () => {
+    globals.choices = [{ label: "opt1", value: "chosen value 1" }];
+    const msg = createMockMessage();
+    await choose.execute(msg, ["9"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("invalid option"),
+    );
+  });
+
+  it("tells the user to be prompted first when there are no prior choices", async () => {
+    const msg = createMockMessage();
+    await choose.execute(msg, ["1"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "Please use this command after being prompted by the bot.",
+    );
+  });
+});
+
+describe("dtnw (days.js)", () => {
+  it("returns majors and minors", async () => {
+    const msg = createMockMessage();
+    await days.execute(msg, []);
+    const sent = msg.channel.send.mock.calls[0][0];
+    expect(sent).toEqual(expect.stringContaining("Majors:"));
+    expect(sent).toEqual(expect.stringContaining("Minors:"));
+  });
+});
+
+describe("invaderdeck (deckCalc.js)", () => {
+  it("computes a single-adversary invader deck", async () => {
+    const msg = createMockMessage();
+    await deckCalc.execute(msg, ["prussia", "0"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("invader deck is:"),
+    );
+  });
+
+  it("computes a double-adversary invader deck", async () => {
+    const msg = createMockMessage();
+    await deckCalc.execute(msg, ["prussia", "0", "england", "0"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("invader deck is:"),
+    );
+  });
+
+  it("reports an error for a bad adversary instead of throwing", async () => {
+    const msg = createMockMessage();
+    await deckCalc.execute(msg, ["bogus", "0"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("not found"),
+    );
+  });
+});
+
+describe("draw", () => {
+  it("draws multiple cards as a bulleted list", async () => {
+    const msg = createMockMessage();
+    await draw.execute(msg, ["minor"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("* "),
+    );
+  });
+
+  it("draws a single card as a bare string", async () => {
+    const msg = createMockMessage();
+    await draw.execute(msg, ["minor", "1"]);
+    const sent = msg.channel.send.mock.calls[0][0];
+    expect(typeof sent).toBe("string");
+    expect(sent).not.toMatch(/^\s*\*/);
+  });
+
+  it("reports an error for an unknown card type instead of throwing", async () => {
+    const msg = createMockMessage();
+    await draw.execute(msg, ["bogus"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("specify a type of card"),
+    );
+  });
+});
+
+describe("event", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await event.execute(msg, ["slave_rebellion"]);
+    expect(msg.channel.send.mock.calls[0][0]).toBe(
+      "https://sick.oberien.de/imgs/events/slave_rebellion.webp",
+    );
+  });
+});
+
+describe("faq", () => {
+  it("returns the default FAQ link with no args", async () => {
+    const msg = createMockMessage();
+    await faq.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://querki.net/u/darker/spirit-island-faq/#!.3y28a87",
+    );
+  });
+
+  it("builds a search URL from args", async () => {
+    const msg = createMockMessage();
+    await faq.execute(msg, ["gather", "dahan"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://querki.net/u/darker/spirit-island-faq/#!Search-Results",
+      ),
+    );
+  });
+});
+
+describe("fear", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await fear.execute(msg, ["fear_of_the_unseen"]);
+    expect(msg.channel.send.mock.calls[0][0]).toBe(
+      "https://sick.oberien.de/imgs/fears/fear_of_the_unseen.webp",
+    );
+  });
+});
+
+describe("feardeck (fearDeck.js)", () => {
+  it("computes a fear deck for a single adversary", async () => {
+    const msg = createMockMessage();
+    await fearDeck.execute(msg, ["prussia", "0"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("fear deck is"),
+    );
+  });
+});
+
+describe("healing", () => {
+  it("returns the front panel for a healing card by title", async () => {
+    const msg = createMockMessage();
+    await healing.execute(msg, ["roiling"]);
+    expect(msg.channel.send).toHaveBeenCalledWith("https://imgur.com/sGO0Rur");
+  });
+});
+
+describe("help", () => {
+  it("lists the available commands", async () => {
+    const msg = createMockMessage();
+    await help.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("-search"),
+    );
+  });
+});
+
+describe("incarna", () => {
+  it("returns the front panel for an incarna by name", async () => {
+    const msg = createMockMessage();
+    await incarna.execute(msg, ["Towering"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://spiritislandwiki.com/images/f/f2/Towering_Roots_of_the_Jungle_Incarna.png",
+    );
+  });
+});
+
+describe("major", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await major.execute(msg, ["the_trees_and_stones_speak_of_war"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/powers/the_trees_and_stones_speak_of_war.webp",
+    );
+  });
+});
+
+describe("minor", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await minor.execute(msg, ["savage_mawbeasts"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/powers/savage_mawbeasts.webp",
+    );
+  });
+});
+
+describe("power", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await power.execute(msg, ["fields_choked_with_growth"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/powers/fields_choked_with_growth.webp",
+    );
+  });
+});
+
+describe("progression (powerProgression.js)", () => {
+  it("reports when a spirit has no power progression", async () => {
+    const msg = createMockMessage();
+    await powerProgression.execute(msg, TEST_SPIRIT_ARGS);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("does not have a power progression"),
+    );
+  });
+});
+
+describe("random", () => {
+  it("random spirit sends a name and emote", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, ["spirit"]);
+    expect(msg.channel.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("random adversary sends a name/difficulty and emote", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, ["adversary"]);
+    expect(msg.channel.send).toHaveBeenCalledTimes(2);
+    expect(msg.channel.send.mock.calls[0][0]).toEqual(
+      expect.stringContaining("difficulty"),
+    );
+  });
+
+  it("random double sends a leading/supporting writeup", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, ["double"]);
+    expect(msg.channel.send.mock.calls[0][0]).toEqual(
+      expect.stringContaining("LEADING"),
+    );
+    expect(msg.channel.send.mock.calls[0][0]).toEqual(
+      expect.stringContaining("SUPPORTING"),
+    );
+  });
+
+  it("random scenario sends a name and link", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, ["scenario"]);
+    expect(msg.channel.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("random board sends a letter and link", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, ["board"]);
+    expect(msg.channel.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("prompts for a sub-command when given no args", async () => {
+    const msg = createMockMessage();
+    await random.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Do you want a random"),
+    );
+  });
+});
+
+describe("reactionrole (role.js)", () => {
+  it("no-ops when the message isn't in the configured landing channel", async () => {
+    const msg = createMockMessage({ channelId: "some-other-channel" });
+    await role.execute(msg, [], require("discord.js"));
+    expect(msg.channel.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("template (roleAdd.js)", () => {
+  it("sends its placeholder output", async () => {
+    const msg = createMockMessage();
+    await roleAdd.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith("output of command");
+  });
+});
+
+describe("scenario", () => {
+  it("returns the back panel for a scenario by name (default side)", async () => {
+    const msg = createMockMessage();
+    await scenario.execute(msg, ["Blitz"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://i.imgur.com/rbm2vox",
+    );
+  });
+
+  it("lists all scenarios when given no args", async () => {
+    const msg = createMockMessage();
+    await scenario.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Scenarios are:"),
+    );
+  });
+});
+
+describe("search", () => {
+  it("shows help text", async () => {
+    const msg = createMockMessage();
+    await search.execute(msg, ["help"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("Examples:"),
+    );
+  });
+
+  it("builds a search URL from args", async () => {
+    const msg = createMockMessage();
+    await search.execute(msg, ["gather", "dahan"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/?query=gather%20dahan",
+    );
+  });
+});
+
+describe("spirit", () => {
+  it("returns the front panel for an exact spirit match", async () => {
+    const msg = createMockMessage();
+    await spirit.execute(msg, TEST_SPIRIT_ARGS);
+    expect(msg.channel.send).toHaveBeenCalledWith("https://imgur.com/nlpGjjH");
+  });
+
+  it("sends a paginated list when given no args", async () => {
+    const msg = createMockMessage();
+    await spirit.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringMatching(/^__paginated__ pages=\d+$/),
+    );
+  });
+
+  it("reports an error for a search matching nothing", async () => {
+    const msg = createMockMessage();
+    await spirit.execute(msg, ["zzz_no_such_spirit_zzz"]);
+    expect(msg.channel.send).toHaveBeenCalled();
+  });
+});
+
+describe("take", () => {
+  it("returns a single card link for a valid type", async () => {
+    const msg = createMockMessage();
+    await take.execute(msg, ["minor"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^https:\/\/sick\.oberien\.de\/imgs\/powers\/.+\.webp$/,
+      ),
+    );
+  });
+
+  it("reports an error when given no args instead of throwing", async () => {
+    const msg = createMockMessage();
+    await take.execute(msg, []);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("specify a type of card"),
+    );
+  });
+});
+
+describe("unique", () => {
+  it("returns a card link for an exact name", async () => {
+    const msg = createMockMessage();
+    await unique.execute(msg, ["fields_choked_with_growth"]);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      "https://sick.oberien.de/imgs/powers/fields_choked_with_growth.webp",
+    );
+  });
+});
+
+describe("uniques", () => {
+  it("lists a spirit's uniques", async () => {
+    const msg = createMockMessage();
+    await uniques.execute(msg, TEST_SPIRIT_ARGS);
+    expect(msg.channel.send).toHaveBeenCalledWith(
+      expect.stringContaining("has the following uniques"),
+    );
+  });
+});

--- a/tests/helpers/discordMocks.js
+++ b/tests/helpers/discordMocks.js
@@ -1,0 +1,78 @@
+/**
+ * Lightweight stand-ins for the pieces of discord.js that command modules
+ * touch (msg.channel.send, msg.reply, msg.guild.emojis, reaction handles).
+ * Deliberately not a full discord.js Message: command modules under
+ * commands/ never construct or type-check against the real class, they
+ * just call methods on whatever `msg` they're handed.
+ */
+function createSentMessageStub() {
+  return {
+    react: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockMessage({ channelId = "test-channel-id" } = {}) {
+  const channel = {
+    id: channelId,
+    send: jest.fn(async (content) => {
+      msg.__sent.push(content);
+      return createSentMessageStub();
+    }),
+  };
+
+  const msg = {
+    channel,
+    reply: jest.fn(async (content) => {
+      msg.__sent.push(content);
+      return createSentMessageStub();
+    }),
+    author: { id: "test-user-id", username: "tester", bot: false },
+    guild: {
+      emojis: {
+        cache: {
+          find: jest.fn(() => ({ id: "fake-emoji-id", name: "Fast" })),
+        },
+      },
+    },
+    content: "",
+    __sent: [],
+  };
+
+  return msg;
+}
+
+/**
+ * Stubs @sapphire/discord.js-utilities' PaginatedMessage so commands that
+ * build a paginated embed list (spirit.js, aspects.js with no args) can run
+ * without a real discord.js Message/InteractionCollector. Call this from a
+ * test file *before* requiring the command module under test, e.g.:
+ *
+ *   jest.mock("@sapphire/discord.js-utilities", () =>
+ *     require("./helpers/discordMocks").paginatedMessageMock(),
+ *   );
+ */
+function paginatedMessageMock() {
+  return {
+    PaginatedMessage: jest.fn().mockImplementation(() => {
+      const pages = [];
+      const instance = {
+        pages,
+        addPageEmbed(builder) {
+          const fakeEmbed = {
+            setTitle: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockReturnThis(),
+          };
+          if (typeof builder === "function") builder(fakeEmbed);
+          pages.push(fakeEmbed);
+          return instance;
+        },
+        run: jest.fn(async (msg) => {
+          return msg.channel.send(`__paginated__ pages=${pages.length}`);
+        }),
+      };
+      return instance;
+    }),
+  };
+}
+
+module.exports = { createMockMessage, paginatedMessageMock };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-    "compilerOptions": {
-        "target": "ES2022",
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "skipLibCheck": true,
-        "resolveJsonModule": true,
-        "isolatedModules": true
-    }
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true
+    }
+}


### PR DESCRIPTION
## Summary

Supersedes #23 (`talshorer:typescript`), which introduced the TypeScript conversion of `index.js` but was opened from a commit ~25 merges behind `main` and left a couple of things broken. This PR rebases that work onto current `main` and fixes what the rebase surfaced:

- `migrate index.js to typescript` / `index: move commands out of bot` — the original two commits from #23, rebased onto current `main` cleanly (only conflict was `package.json`/`package-lock.json` devDependency churn).
- `tsconfig.json`'s `moduleResolution` changed from `"node"` (hard error under the `typescript@^6` the PR itself pins) to `"bundler"`; bumped `dotenv` since its old types don't resolve under package `exports` in that mode.
- `Dockerfile`'s dev/prod `CMD`s still pointed at `node`/`nodemon index.js`, which no longer exists post-rename — switched both to run via `tsx`, and moved `tsx` into `dependencies` so it survives the prod image's `npm ci --omit=dev`.
- Added a Jest regression suite covering all 30 `commands/*.js` modules plus a test that mirrors `index.ts`'s dynamic command-loading loop, so future changes to the loader or any command get caught automatically.
- Applied `prettier --write .` repo-wide (several files, including `index.ts`, weren't clean) and added `npm run format:check`.
- Added `.github/workflows/ci.yml`: runs the full Jest suite and `prettier --check` on every PR/push to `main`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 137/137 passing across 5 suites
- [x] `npm run format:check` passes
- [x] New GitHub Actions workflow validated locally (steps run clean; installs node-canvas system deps matching the Dockerfile)
- [ ] Reviewer: confirm bot still boots against a real `DISCORD_TOKEN` (not run here — this repo's `.env` has a live token, didn't want to bring the real bot online while testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)